### PR TITLE
Max errors

### DIFF
--- a/rumydata/exception.py
+++ b/rumydata/exception.py
@@ -152,3 +152,7 @@ class NullValueError(UrNotMyDataError):
 
 class NegativeValueError(CellError):
     message = "You're too negative"
+
+
+class MaxExceededError(UrNotMyDataError):
+    pass


### PR DESCRIPTION
Add max errors bailout; defaults to 100. If the number of rows with errors exceeds this limit, the checking stops and the error assertion is raised with an additional error to indicate this.