### PR TITLE
Add Ignore field

### DIFF
--- a/rumydata/__init__.py
+++ b/rumydata/__init__.py
@@ -2,4 +2,4 @@ from rumydata import field
 from rumydata import rules
 from rumydata.file import Layout, File
 
-__version__ = '0.0.9'
+__version__ = '0.0.10'

--- a/rumydata/field.py
+++ b/rumydata/field.py
@@ -51,6 +51,22 @@ class Field(BaseSubject):
         return any([issubclass(type(r), rule_type) for r in self.rules])
 
 
+class Ignore(Field):
+    """
+    Ignore the values found in this field. This will cause other dependencies (like row checks) to
+    treat any values in this field as if they were empty. While the check method still exists, this
+    class overwrites those inherited methods to intentionally have no effect.
+    """
+
+    # noinspection PyMissingConstructor
+    def __init__(self):
+        self.rules = []
+        self.descriptors = {}
+
+    def __check__(self, *args, **kwargs):
+        pass
+
+
 class Text(Field):
     def __init__(self, max_length, min_length=None, **kwargs):
         super().__init__(**kwargs)

--- a/rumydata/file.py
+++ b/rumydata/file.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Union, Dict
 
 from rumydata import exception as ex
+from rumydata import field
 from rumydata.base import BaseSubject
 from rumydata.rules import file, column as cr, header as hr, row as rr, cell as clr
 
@@ -35,8 +36,6 @@ class Layout(BaseSubject):
     def __check__(self, row, rule_type, rix=None):
         if rule_type == hr.Rule and self.skip_header:
             return
-        elif rule_type == rr.Rule and self.empty_row_ok and all([x == '' for x in row]):
-            return
 
         e = super().__check__(row, rule_type=rule_type)
 
@@ -45,6 +44,10 @@ class Layout(BaseSubject):
 
         if rule_type == rr.Rule:
             row = dict(zip(self.definition.keys(), row))
+            ignore = {k: isinstance(v, field.Ignore) for k, v in self.definition.items()}
+            # if empty row is okay, and all fields are either empty, or Ignore class
+            if self.empty_row_ok and all([('' if ignore[k] else v) == '' for k, v in row.items()]):
+                return
 
             for cix, (name, val) in enumerate(row.items()):
                 t = self.definition[name]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -434,3 +434,25 @@ def test_empty_row_file_good(tmpdir):
     cols = rumydata.file.Layout({'x': field.Field()}, empty_row_ok=True)
     f = write_row(tmpdir, cols, [['1'], ['2'], ['']], rows=True)
     assert not File(cols).check(f)
+
+
+@pytest.mark.parametrize('cell', [
+    '',
+    '1',
+    '8k;asdfkl;asdf'
+])
+def test_ignore_cell(cell):
+    assert not field.Ignore().check_cell(cell)
+
+
+@pytest.mark.parametrize('row', [
+    (['1', '']),
+    (['', '']),
+    (['1', '1'])
+])
+def test_ignore_row(row):
+    """ Test that ignore rows count as empty for the purpose of accepting empty rows """
+    lay = rumydata.file.Layout(
+        {'x': field.Ignore(), 'y': field.Integer(1)}, empty_row_ok=True
+    )
+    assert not lay.check_row(row)


### PR DESCRIPTION
The addition of the Field type allows files with meaningless data (e.g. Excel
formulas) to be accounted for, and summarily dismissed. This is particularly
useful in the case of empty row checks, as it allows us to consider the row
empty if there are no values in any non-Ignore field.