### PR TITLE
Field strip

### DIFF
--- a/rumydata/exception.py
+++ b/rumydata/exception.py
@@ -181,3 +181,13 @@ class CellError(UrNotMyDataError):
             message += f' ({kwargs.get("name")})'
         message += f'; {msg}' if msg else ''
         super().__init__(message, errors)
+
+
+class PreProcessingError(UrNotMyDataError):
+    """
+    Data Preprocessing Exception
+
+    Thrown specifically when the data pre-processing step for a subject fails.
+    This is treated differently than the exceptions thrown by all fields, since
+    pre-processing exceptions prevent any further rules from being checked.
+    """

--- a/rumydata/field.py
+++ b/rumydata/field.py
@@ -34,6 +34,9 @@ class Field(_BaseSubject):
         can be null (blank). Defaults to False, which will cause errors to
         be raised when checking empty strings.
     :param rules: a list of rules to apply to this field during checks.
+    :param strip: (optional) apply pre-processing to values in the field which
+        applies the str.strip method, removing leading and trailing whitespaces,
+        prior to checking rules.
     """
 
     def __init__(self, nullable=False, rules: list = None, **kwargs):

--- a/rumydata/field.py
+++ b/rumydata/field.py
@@ -36,9 +36,10 @@ class Field(_BaseSubject):
     :param rules: a list of rules to apply to this field during checks.
     """
 
-    def __init__(self, nullable=False, rules: list = None):
+    def __init__(self, nullable=False, rules: list = None, **kwargs):
         super().__init__(rules)
         self.nullable = nullable
+        self.strip = kwargs.get('strip')
 
         if not self.nullable:
             self.rules.append(clr.NotNull())
@@ -92,7 +93,7 @@ class Field(_BaseSubject):
         if self.nullable and rule_type == clr.Rule and data == '':
             pass
         else:
-            e = super()._check(data, rule_type=rule_type)
+            e = super()._check(data, rule_type=rule_type, strip=self.strip)
             if e:
                 if rule_type == cr.Rule:
                     return ex.ColumnError(cix, errors=e, **kwargs)

--- a/rumydata/rules/cell.py
+++ b/rumydata/rules/cell.py
@@ -31,6 +31,20 @@ __all__ = [
 class Rule(_BaseRule):
     """ Cell Rule """
 
+    @staticmethod
+    def _pre_process(data: Union[str, Tuple[str, Dict]], **kwargs) -> Union[str, Tuple[str, Dict]]:
+        d1 = data if isinstance(data, str) else data[0]
+        d2 = data[1] if isinstance(data, tuple) else {}
+
+        if kwargs.get('strip'):
+            d1 = d1.strip()
+            d2 = {k: v.strip() for k, v in d2.items()}
+
+        if d2:
+            return d1, d2
+        else:
+            return d1
+
     def _prepare(self, data: Union[str, Tuple[str, Dict]]) -> tuple:
         if isinstance(data, str):
             return data,

--- a/rumydata/rules/column.py
+++ b/rumydata/rules/column.py
@@ -28,6 +28,12 @@ __all__ = ['Unique']
 class Rule(_BaseRule):
     """ Column Rule """
 
+    @staticmethod
+    def _pre_process(data: List[str], **kwargs) -> List[str]:
+        if kwargs.get('strip'):
+            data = [d.strip() for d in data]
+        return data
+
     def _prepare(self, data: List[str]) -> tuple:
         return data,
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -240,17 +240,41 @@ def test_ignore_row(row):
     assert not lay.check_row(row)
 
 
-def test_debug_mode(mocker):
+def test_debug_mode_pre_process(mocker):
     """ Debug messages should only appear when debug method has been patched """
     try:
         # noinspection PyTypeChecker
-        field.Integer(1).check_cell(None)
+        field.Date().check_cell(None)
     except AssertionError as ae:
         assert '[DEBUG]' not in str(ae)
 
     mocker.patch('rumydata.exception.debug', return_value=True)
     try:
         # noinspection PyTypeChecker
-        field.Integer(1).check_cell(None)
+        field.Date().check_cell(None)
     except AssertionError as ae:
         assert '[DEBUG]' in str(ae)
+
+
+def test_debug_mode(mocker):
+    """ Debug messages should only appear when debug method has been patched """
+    try:
+        # noinspection PyTypeChecker
+        CsvFile({}).check(1)
+    except AssertionError as ae:
+        assert '[DEBUG]' not in str(ae)
+
+    mocker.patch('rumydata.exception.debug', return_value=True)
+    try:
+        # noinspection PyTypeChecker
+        CsvFile({}).check(1)
+    except AssertionError as ae:
+        assert '[DEBUG]' in str(ae)
+
+
+def test_cell_trim():
+    assert not field.Choice(['x'], strip=True).check_cell(' x ')
+
+
+def test_column_trim():
+    assert not field.Choice(['x'], strip=True).check_column([' x '])

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -260,10 +260,7 @@ def test_debug_mode_pre_process(mocker):
 def test_debug_mode(mocker):
     """ Debug messages should only appear when debug method has been patched """
 
-    def rex():
-        raise Exception
-
-    r = make_static_cell_rule(rex, 'raise an exception')
+    r = make_static_cell_rule(lambda x: 1 / 0, 'raise an exception')
     try:
         # noinspection PyTypeChecker
         field.Field(rules=[r]).check_cell('1')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -16,6 +16,7 @@ import rumydata.table
 from rumydata import exception as ex
 from rumydata import field
 from rumydata.rules import column as cr, table as tr, header as hr
+from rumydata.rules.cell import make_static_cell_rule
 from rumydata.table import CsvFile, ExcelFile
 
 
@@ -258,16 +259,21 @@ def test_debug_mode_pre_process(mocker):
 
 def test_debug_mode(mocker):
     """ Debug messages should only appear when debug method has been patched """
+
+    def rex():
+        raise Exception
+
+    r = make_static_cell_rule(rex, 'raise an exception')
     try:
         # noinspection PyTypeChecker
-        CsvFile({}).check(1)
+        field.Field(rules=[r]).check_cell('1')
     except AssertionError as ae:
         assert '[DEBUG]' not in str(ae)
 
     mocker.patch('rumydata.exception.debug', return_value=True)
     try:
         # noinspection PyTypeChecker
-        CsvFile({}).check(1)
+        field.Field(rules=[r]).check_cell('1')
     except AssertionError as ae:
         assert '[DEBUG]' in str(ae)
 


### PR DESCRIPTION
Add `strip` kwarg to `Field` constructor. This will trigger pre-processing on any values to be checked by that field, which will remove leading and trailing whitespaces.