### PR TITLE
Fix a bug which caused nullable check to fail

### DIFF
--- a/rumydata/__init__.py
+++ b/rumydata/__init__.py
@@ -34,4 +34,4 @@ from rumydata import rules
 from rumydata.menu import menu
 from rumydata.table import *
 
-__version__ = '0.5.1'
+__version__ = '0.5.2'

--- a/rumydata/field.py
+++ b/rumydata/field.py
@@ -93,7 +93,8 @@ class Field(_BaseSubject):
         """
 
         # if data is nullable and value is empty, skip all checks
-        if self.nullable and rule_type == clr.Rule and data == '':
+        empty = data[0] == '' if isinstance(data, tuple) else data == ''
+        if self.nullable and rule_type == clr.Rule and empty:
             pass
         else:
             e = super()._check(data, rule_type=rule_type, strip=self.strip)

--- a/tests/test_row.py
+++ b/tests/test_row.py
@@ -1,11 +1,17 @@
 import pytest
 
-from rumydata import table
+from rumydata import table, Layout, field
 from rumydata.rules import row as rr, header as hr
 
 
 def test_row_good(basic):
     assert not table.Layout(basic).check_row(['1', '2', '2020-01-01', 'X'])
+
+
+def test_row_choice(basic):
+    lay = Layout({'c1': field.Choice(['x'], nullable=True)})
+    assert not lay.check_row(['x'])
+    assert not lay.check_row([''])
 
 
 @pytest.mark.parametrize('value,err', [


### PR DESCRIPTION
Certain rule preparers return tuples instead of string, but the nullable check
was only looking for empty strings in its bypass. This implements a fix that
allows the null bypass to handle either a string or a tuple.