### PR TITLE
Add some parameters to load_workbook

### DIFF
--- a/rumydata/table.py
+++ b/rumydata/table.py
@@ -356,7 +356,7 @@ class ExcelFile(_BaseFile):
 
             def __enter__(self) -> Iterable:
                 from openpyxl import load_workbook
-                wb = load_workbook(file)
+                wb = load_workbook(file, read_only=True, data_only=True)
                 sheet_name = self.excel_kwargs.get('sheet')
                 ws = wb[sheet_name] if sheet_name else wb.active
                 return ws.values


### PR DESCRIPTION
I found in the documentation that `read_only` could improve performance, and anecdotally this seems to be super accurate, at least when running thru a debugger. Given the nature of this package I suspect this should be a default setting when looking at excel files.

The `data_only` parameter reads Excel cells as their formulated value, rather than the formula input into the Excel cell... I'm not sure if this should be optional (probably), but I still can't quite wrap my mind around how to properly make this pass thru the several layers of class inheritance :( So I'm just throwing it here as an example of where the parameter might need to be in case you want to incorporate it in some way