### PR TITLE
Set action trigger to main pull request

### DIFF
--- a/.github/workflows/python_latest_version_test.yml
+++ b/.github/workflows/python_latest_version_test.yml
@@ -1,6 +1,9 @@
 name: Test Latest Published Version
 
-on: [push]
+on:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   version:


### PR DESCRIPTION
Instead of triggering the published version check with each push, we can wait until we are requesting a pull to `main`. This let's us see commits pass, even if they haven't updated the version yet.