### PR TITLE
Alter the way bad file name is reported

### DIFF
--- a/rumydata/table.py
+++ b/rumydata/table.py
@@ -237,7 +237,7 @@ class _BaseFile(_BaseSubject):
         p = Path(filepath) if isinstance(filepath, str) else filepath
         e = super()._check(p, rule_type=table.Rule)  # check files-based rules first
         if e:
-            return ex.FileError(file=p.as_posix(), errors=e)
+            return ex.FileError(file=p.name, errors=e)
 
         column_cache = {
             k: [] for k, v in self.layout.layout.items()


### PR DESCRIPTION
Just a small suggestion to remove the full path when reporting a bad file name, but rather just report the file name. The reporting already behaves this way when reporting _other_ errors, but not when we find a badly named file.

Not sure if you want to review these types of small changes or not