### PR TITLE
Add `ignore_if` parameter on Field class

### DIFF
--- a/rumydata/__init__.py
+++ b/rumydata/__init__.py
@@ -35,4 +35,4 @@ from rumydata import rules
 from rumydata.menu import menu
 from rumydata.table import *
 
-__version__ = '1.1.0'
+__version__ = '1.1.0-dev'

--- a/rumydata/field.py
+++ b/rumydata/field.py
@@ -37,10 +37,13 @@ class Field(_BaseSubject):
     :param strip: (optional) apply pre-processing to values in the field which
         applies the str.strip method, removing leading and trailing whitespaces,
         prior to checking rules.
+    :param ignore_if: (optional) specify values which will force the field to be
+        treated as an Ignore field. Can be a single value or list of values
     """
 
     def __init__(self, nullable=False, rules: list = None, **kwargs):
         self.strip = kwargs.pop('strip', None)
+        self.ignore_if = kwargs.pop('ignore_if', None)
         super().__init__(rules, **kwargs)
         self.nullable = nullable
 

--- a/rumydata/table.py
+++ b/rumydata/table.py
@@ -149,7 +149,12 @@ class Layout(_BaseSubject):
 
         if rule_type == rr.Rule:
             row = dict(zip(self.layout.keys(), row))
-            ignore = {k: isinstance(v, field.Ignore) for k, v in self.layout.items()}
+            # if any of the fields are Ignore, or if the field uses the ignore_if parameter and the value matches the
+            # specified value we ignore them. Handles cases where a string or list is specified
+            ignore = {k: (isinstance(v, field.Ignore) if isinstance(v, field.Ignore) else row[k] in self.layout[
+                k].ignore_if if isinstance(self.layout[k].ignore_if, List) else row[k] == self.layout[k].ignore_if) for
+                      k, v in self.layout.items()}
+
             # if empty row is okay, and all fields are either empty, or Ignore class
             if self.empty_row_ok and all([('' if ignore[k] else v) == '' for k, v in row.items()]):
                 return

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -183,10 +183,19 @@ def test_no_header_default_bad(tmpdir):
     assert False if CsvFile(layout)._list_errors(p) == [None] else True
 
 
-def test_ignore_if(tmpdir):
+def test_ignore_if_single(tmpdir):
     hid = uuid4().hex[:5]
     p = Path(tmpdir, hid)
     p.write_text('\n'.join(['c1,c2', "x,", 'c,d']))
     layout = Layout({'c1': Text(1, ignore_if='x'), 'c2': Text(1)}, empty_row_ok=True)
+    results = CsvFile(layout).check(p)
+    assert True if not results else False
+
+
+def test_ignore_if_list(tmpdir):
+    hid = uuid4().hex[:5]
+    p = Path(tmpdir, hid)
+    p.write_text('\n'.join(['c1,c2', 'x,z', 'c,d', ',', 'z,', 'x,x']))
+    layout = Layout({'c1': Text(1, ignore_if=['x', 'z']), 'c2': Text(1)}, empty_row_ok=True)
     results = CsvFile(layout).check(p)
     assert True if not results else False

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -183,19 +183,27 @@ def test_no_header_default_bad(tmpdir):
     assert False if CsvFile(layout)._list_errors(p) == [None] else True
 
 
-def test_ignore_if_single(tmpdir):
+def test_ignore_if_single_good(tmpdir):
     hid = uuid4().hex[:5]
     p = Path(tmpdir, hid)
-    p.write_text('\n'.join(['c1,c2', "x,", 'c,d']))
+    p.write_text('\n'.join(['c1,c2', 'x,', 'c,d']))
     layout = Layout({'c1': Text(1, ignore_if='x'), 'c2': Text(1)}, empty_row_ok=True)
     results = CsvFile(layout).check(p)
     assert True if not results else False
 
 
+def test_ignore_if_single_bad(tmpdir):
+    hid = uuid4().hex[:5]
+    p = Path(tmpdir, hid)
+    p.write_text('\n'.join(['c1,c2', 'z,', 'c,d']))
+    layout = Layout({'c1': Text(1, ignore_if='x'), 'c2': Text(1)}, empty_row_ok=True)
+    assert False if CsvFile(layout)._list_errors(p) == [None] else True
+
+
 def test_ignore_if_list(tmpdir):
     hid = uuid4().hex[:5]
     p = Path(tmpdir, hid)
-    p.write_text('\n'.join(['c1,c2', 'x,z', 'c,d', ',', 'z,', 'x,x']))
+    p.write_text('\n'.join(['c1,c2', 'x,z', 'c,d', ',', 'z,', 'x,']))
     layout = Layout({'c1': Text(1, ignore_if=['x', 'z']), 'c2': Text(1)}, empty_row_ok=True)
     results = CsvFile(layout).check(p)
     assert True if not results else False

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -181,3 +181,12 @@ def test_no_header_default_bad(tmpdir):
     p.write_text('\n'.join(['a,b', 'c,d']))
     layout = Layout({'c1': Text(1), 'c2': Text(1)})
     assert False if CsvFile(layout)._list_errors(p) == [None] else True
+
+
+def test_ignore_if(tmpdir):
+    hid = uuid4().hex[:5]
+    p = Path(tmpdir, hid)
+    p.write_text('\n'.join(['c1,c2', "x,", 'c,d']))
+    layout = Layout({'c1': Text(1, ignore_if='x'), 'c2': Text(1)}, empty_row_ok=True)
+    results = CsvFile(layout).check(p)
+    assert True if not results else False


### PR DESCRIPTION
I ran into a use case where I had an Excel file that had a prepopulated value (of 'No') for all rows for a given Excel table. This value would be updated to 'Yes' in certain cases, but it left me in a weird position where I wanted to consider these extra rows as 'empty' when a given value is present. This solution allows one to add a value, or list of values, as an `ignore_if` parameter when defining the fields of a layout.