### PR TITLE
Add `ignore_if` parameter on Field class

### DIFF
--- a/rumydata/__init__.py
+++ b/rumydata/__init__.py
@@ -35,4 +35,4 @@ from rumydata import rules
 from rumydata.menu import menu
 from rumydata.table import *
 
-__version__ = '1.1.0'
+__version__ = '1.1.0-dev'

--- a/rumydata/__init__.py
+++ b/rumydata/__init__.py
@@ -35,4 +35,4 @@ from rumydata import rules
 from rumydata.menu import menu
 from rumydata.table import *
 
-__version__ = '1.1.0-dev'
+__version__ = '1.2.0-dev'

--- a/rumydata/field.py
+++ b/rumydata/field.py
@@ -37,13 +37,11 @@ class Field(_BaseSubject):
     :param strip: (optional) apply pre-processing to values in the field which
         applies the str.strip method, removing leading and trailing whitespaces,
         prior to checking rules.
-    :param ignore_if: (optional) specify values which will force the field to be
-        treated as an Ignore field. Can be a single value or list of values
     """
 
     def __init__(self, nullable=False, rules: list = None, **kwargs):
         self.strip = kwargs.pop('strip', None)
-        self.ignore_if = kwargs.pop('ignore_if', None)
+        self.ignore_if = None
         super().__init__(rules, **kwargs)
         self.nullable = nullable
 

--- a/rumydata/field.py
+++ b/rumydata/field.py
@@ -37,10 +37,13 @@ class Field(_BaseSubject):
     :param strip: (optional) apply pre-processing to values in the field which
         applies the str.strip method, removing leading and trailing whitespaces,
         prior to checking rules.
+    :param ignore_if: (optional) specify values which will force the field to be
+        treated as an Ignore field. Can be a single value or list of values
     """
 
     def __init__(self, nullable=False, rules: list = None, **kwargs):
         self.strip = kwargs.pop('strip', None)
+        self.ignore_if = kwargs.pop('ignore_if', None)
         super().__init__(rules, **kwargs)
         self.nullable = nullable
 

--- a/rumydata/field.py
+++ b/rumydata/field.py
@@ -41,7 +41,7 @@ class Field(_BaseSubject):
 
     def __init__(self, nullable=False, rules: list = None, **kwargs):
         self.strip = kwargs.pop('strip', None)
-        self.ignore_if = None
+        self._ignore_if = None
         super().__init__(rules, **kwargs)
         self.nullable = nullable
 

--- a/rumydata/table.py
+++ b/rumydata/table.py
@@ -149,7 +149,12 @@ class Layout(_BaseSubject):
 
         if rule_type == rr.Rule:
             row = dict(zip(self.layout.keys(), row))
-            ignore = {k: isinstance(v, field.Ignore) for k, v in self.layout.items()}
+            # if any of the fields are Ignore, or if the field uses the ignore_if parameter and the value matches the
+            # specified value we ignore them. Handles cases where a string or list is specified
+            ignore = {k: (isinstance(v, field.Ignore) if isinstance(v, field.Ignore) else row[k] in self.layout[
+                k].ignore_if if isinstance(self.layout[k].ignore_if, List) else row[k] == self.layout[k].ignore_if) for
+                      k, v in self.layout.items()}
+
             # if empty row is okay, and all fields are either empty, or Ignore class
             if self.empty_row_ok and all([('' if ignore[k] else v) == '' for k, v in row.items()]):
                 return

--- a/rumydata/table.py
+++ b/rumydata/table.py
@@ -149,11 +149,11 @@ class Layout(_BaseSubject):
 
         if rule_type == rr.Rule:
             row = dict(zip(self.layout.keys(), row))
-            # if any of the fields are Ignore, or if the field uses the ignore_if parameter and the value matches the
+            # if any of the fields are Ignore, or if the field uses the _ignore_if parameter and the value matches the
             # specified value we ignore them. Handles cases where a string or list is specified
             ignore = {k: (isinstance(v, field.Ignore) if isinstance(v, field.Ignore) else row[k] in self.layout[
-                k].ignore_if if isinstance(self.layout[k].ignore_if, List) else row[k] == self.layout[k].ignore_if) for
-                      k, v in self.layout.items()}
+                k]._ignore_if if isinstance(self.layout[k]._ignore_if, List) else row[k] == self.layout[k]._ignore_if)
+                      for k, v in self.layout.items()}
 
             # if empty row is okay, and all fields are either empty, or Ignore class
             if self.empty_row_ok and all([('' if ignore[k] else v) == '' for k, v in row.items()]):
@@ -205,7 +205,7 @@ class _BaseFile(_BaseSubject):
 
         if self.ignore_exceptions:
             for k, v in self.ignore_exceptions.items():
-                self.layout.layout[k].ignore_if = v
+                self.layout.layout[k]._ignore_if = v
 
         self.rules.extend([
             table.FileExists()
@@ -297,7 +297,8 @@ class _BaseFile(_BaseSubject):
 
                 if re:
                     e.append(re)
-                    if rix == (0 + self.skip_rows) and self.layout.no_header is False:  # if header error present, stop checking rows
+                    if rix == (
+                            0 + self.skip_rows) and self.layout.no_header is False:  # if header error present, stop checking rows
                         break
                     if len(e) > self.max_errors:
                         e.append(max_error_rule._exception_msg())

--- a/rumydata/table.py
+++ b/rumydata/table.py
@@ -190,14 +190,23 @@ class _BaseFile(_BaseSubject):
         This is used to prevent overly verbose (and mostly useless)
         validation reports from being generated. The error limit can be set to
         unlimited by providing a value of -1.
+    :param ignore_exceptions: (optional) specify a dictionary of column names
+        mapping to a value or list of values which will force the field to be
+        treated as an Ignore field when the value is encountered.
     """
 
     def __init__(self, layout: Layout, skip_rows=0, max_errors=100, file_name_pattern=False, **kwargs):
         self.skip_rows = skip_rows
         self.max_errors = max_errors
+        self.ignore_exceptions = kwargs.pop('ignore_exceptions', None)
 
         super().__init__(**kwargs)
         self.layout = Layout(layout) if isinstance(layout, Dict) else layout
+
+        if self.ignore_exceptions:
+            for k, v in self.ignore_exceptions.items():
+                self.layout.layout[k].ignore_if = v
+
         self.rules.extend([
             table.FileExists()
         ])
@@ -381,7 +390,7 @@ class ExcelFile(_BaseFile):
 
         x = {x: kwargs.pop(x, None) for x in ['sheet']}
         self.excel_kwargs = {k: v for k, v in x.items() if v}
-
+        # add ignore_ifs to the layout's fields when this gets constructed
         super().__init__(layout, skip_rows, max_errors, **kwargs)
 
     def _rows(self, file: Path):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -183,10 +183,19 @@ def test_no_header_default_bad(tmpdir):
     assert False if CsvFile(layout)._list_errors(p) == [None] else True
 
 
-def test_ignore_if(tmpdir):
+def test_ignore_if_single(tmpdir):
     hid = uuid4().hex[:5]
     p = Path(tmpdir, hid)
     p.write_text('\n'.join(['c1,c2', "x,", 'c,d']))
     layout = Layout({'c1': Text(1, ignore_if='x'), 'c2': Text(1)}, empty_row_ok=True)
+    results = CsvFile(layout).check(p)
+    assert True if not results else False
+
+
+def test_ignore_if_list(tmpdir):
+    hid = uuid4().hex[:5]
+    p = Path(tmpdir, hid)
+    p.write_text('\n'.join(['c1,c2', 'x,z', 'c,d', ',', 'z,', 'x,x']))
+    layout = Layout({'c1': Text(1, ignore_if=['x', 'z']), 'c2': Text(1)}, empty_row_ok=True)
     results = CsvFile(layout).check(p)
     assert True if not results else False

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -183,19 +183,27 @@ def test_no_header_default_bad(tmpdir):
     assert False if CsvFile(layout)._list_errors(p) == [None] else True
 
 
-def test_ignore_if_single(tmpdir):
+def test_ignore_if_single_good(tmpdir):
     hid = uuid4().hex[:5]
     p = Path(tmpdir, hid)
-    p.write_text('\n'.join(['c1,c2', "x,", 'c,d']))
+    p.write_text('\n'.join(['c1,c2', 'x,', 'c,d']))
     layout = Layout({'c1': Text(1, ignore_if='x'), 'c2': Text(1)}, empty_row_ok=True)
     results = CsvFile(layout).check(p)
     assert True if not results else False
 
 
+def test_ignore_if_single_bad(tmpdir):
+    hid = uuid4().hex[:5]
+    p = Path(tmpdir, hid)
+    p.write_text('\n'.join(['c1,c2', 'z,', 'c,d']))
+    layout = Layout({'c1': Text(1, ignore_if='x'), 'c2': Text(1)}, empty_row_ok=True)
+    assert False if CsvFile(layout)._list_errors(p) == [None] else True
+
+
 def test_ignore_if_list(tmpdir):
     hid = uuid4().hex[:5]
     p = Path(tmpdir, hid)
-    p.write_text('\n'.join(['c1,c2', 'x,z', 'c,d', ',', 'z,', 'x,x']))
+    p.write_text('\n'.join(['c1,c2', 'x,z', 'c,d', ',', 'z,', 'x,']))
     layout = Layout({'c1': Text(1, ignore_if=['x', 'z']), 'c2': Text(1)}, empty_row_ok=True)
     results = CsvFile(layout).check(p)
     assert True if not results else False

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -181,3 +181,12 @@ def test_no_header_default_bad(tmpdir):
     p.write_text('\n'.join(['a,b', 'c,d']))
     layout = Layout({'c1': Text(1), 'c2': Text(1)})
     assert False if CsvFile(layout)._list_errors(p) == [None] else True
+
+
+def test_ignore_if(tmpdir):
+    hid = uuid4().hex[:5]
+    p = Path(tmpdir, hid)
+    p.write_text('\n'.join(['c1,c2', "x,", 'c,d']))
+    layout = Layout({'c1': Text(1, ignore_if='x'), 'c2': Text(1)}, empty_row_ok=True)
+    results = CsvFile(layout).check(p)
+    assert True if not results else False

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -187,8 +187,8 @@ def test_ignore_if_single_good(tmpdir):
     hid = uuid4().hex[:5]
     p = Path(tmpdir, hid)
     p.write_text('\n'.join(['c1,c2', 'x,', 'c,d']))
-    layout = Layout({'c1': Text(1, ignore_if='x'), 'c2': Text(1)}, empty_row_ok=True)
-    results = CsvFile(layout).check(p)
+    layout = Layout({'c1': Text(1), 'c2': Text(1)}, empty_row_ok=True)
+    results = CsvFile(layout, ignore_exceptions={'c1': 'x'}).check(p)
     assert True if not results else False
 
 
@@ -196,14 +196,14 @@ def test_ignore_if_single_bad(tmpdir):
     hid = uuid4().hex[:5]
     p = Path(tmpdir, hid)
     p.write_text('\n'.join(['c1,c2', 'z,', 'c,d']))
-    layout = Layout({'c1': Text(1, ignore_if='x'), 'c2': Text(1)}, empty_row_ok=True)
-    assert False if CsvFile(layout)._list_errors(p) == [None] else True
+    layout = Layout({'c1': Text(1), 'c2': Text(1)}, empty_row_ok=True)
+    assert False if CsvFile(layout, ignore_exceptions={'c1': 'x'})._list_errors(p) == [None] else True
 
 
 def test_ignore_if_list(tmpdir):
     hid = uuid4().hex[:5]
     p = Path(tmpdir, hid)
     p.write_text('\n'.join(['c1,c2', 'x,z', 'c,d', ',', 'z,', 'x,']))
-    layout = Layout({'c1': Text(1, ignore_if=['x', 'z']), 'c2': Text(1)}, empty_row_ok=True)
-    results = CsvFile(layout).check(p)
+    layout = Layout({'c1': Text(1), 'c2': Text(1)}, empty_row_ok=True)
+    results = CsvFile(layout, ignore_exceptions={'c1': ['x', 'z']}).check(p)
     assert True if not results else False


### PR DESCRIPTION
I ran into a use case where I had an Excel file that had a prepopulated value (of 'No') for all rows for a given Excel table. This value would be updated to 'Yes' in certain cases, but it left me in a weird position where I wanted to consider these extra rows as 'empty' when a given value is present. This solution allows one to add a value, or list of values, as an ignore_if parameter when defining the fields of a layout.