### PR TITLE
no_header - an error in the first row causes subsequent rows to not report their errors

### DIFF
--- a/rumydata/table.py
+++ b/rumydata/table.py
@@ -283,7 +283,7 @@ class _BaseFile(_BaseSubject):
 
                 if re:
                     e.append(re)
-                    if rix == 0 and self.layout.no_header is False:  # if header error present, stop checking rows
+                    if rix == (0 + self.skip_rows) and self.layout.no_header is False:  # if header error present, stop checking rows
                         break
                     if len(e) > self.max_errors:
                         e.append(max_error_rule._exception_msg())

--- a/rumydata/table.py
+++ b/rumydata/table.py
@@ -288,7 +288,7 @@ class _BaseFile(_BaseSubject):
                     if len(e) > self.max_errors:
                         e.append(max_error_rule._exception_msg())
                         break
-                if rix > 0 or self.layout.no_header is True:
+                if rix > (0 + self.skip_rows) or self.layout.no_header is True:
                     for k, ix in column_cache_map.items():
                         column_cache[k].append(row[ix])
 

--- a/rumydata/table.py
+++ b/rumydata/table.py
@@ -283,12 +283,12 @@ class _BaseFile(_BaseSubject):
 
                 if re:
                     e.append(re)
-                    if rix == 0:  # if header error present, stop checking rows
+                    if rix == 0 and self.layout.no_header is False:  # if header error present, stop checking rows
                         break
                     if len(e) > self.max_errors:
                         e.append(max_error_rule._exception_msg())
                         break
-                if rix > 0:
+                if rix > 0 or self.layout.no_header is True:
                     for k, ix in column_cache_map.items():
                         column_cache[k].append(row[ix])
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -191,3 +191,11 @@ def test_no_header_default_bad(tmpdir):
     p.write_text('\n'.join(['a,b', 'c,d']))
     layout = Layout({'c1': Text(1), 'c2': Text(1)})
     assert False if CsvFile(layout)._list_errors(p) == [None] else True
+
+
+def test_no_header_with_column_rule(tmpdir):
+    hid = uuid4().hex[:5]
+    p = Path(tmpdir, hid)
+    p.write_text('\n'.join(['a', 'a']))
+    layout = Layout({'c1': Text(1, rules=[Unique()])}, no_header=True)
+    assert True if CsvFile(layout)._has_error(p, Unique.rule_exception()) else False

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -222,10 +222,14 @@ def test_skip_rows_bad_header(tmpdir):
         [csv._has_error(p, rules.header.ColumnOrder.rule_exception()), not csv._has_error(p, Unique.rule_exception())])
 
 
-def test_skip_rows_skips_columns_errors(tmpdir):
+@pytest.mark.parametrize('skip, expected', [
+    (1, True),
+    (2, False)
+])
+def test_skip_rows_skips_columns_errors(tmpdir, skip, expected):
     hid = uuid4().hex[:5]
     p = Path(tmpdir, hid)
-    p.write_text('\n'.join(['aa', 'c1', 'aa']))
-    layout = Layout({'c1': Text(2, rules=[Unique()])})
-    csv = CsvFile(layout, skip_rows=1)
-    assert not csv._has_error(p, Unique.rule_exception())
+    p.write_text('\n'.join(['a', 'a', 'a', 'a']))
+    layout = Layout({'a': Text(2, rules=[Unique()])})
+    csv = CsvFile(layout, skip_rows=skip)
+    assert csv._has_error(p, Unique.rule_exception()) is expected

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -7,6 +7,7 @@ from openpyxl import Workbook
 from rumydata.field import Integer, Field, Text
 from rumydata.rules.column import Unique
 from rumydata.table import Layout, CsvFile, ExcelFile, _BaseFile
+from rumydata import exception as ex
 from tests.utils import mock_no_module
 
 
@@ -138,9 +139,18 @@ def test_excel_cell_format():
 def test_no_header_true_bad(tmpdir):
     hid = uuid4().hex[:5]
     p = Path(tmpdir, hid)
-    p.write_text('\n'.join(['aaaa,b', 'c,d']))
+    p.write_text('\n'.join(['aa,b', 'c,d']))
     layout = Layout({'c1': Text(1), 'c2': Text(1)}, no_header=True)
     assert False if CsvFile(layout)._list_errors(p) == [None] else True
+
+
+def test_no_header_true_bad_plus(tmpdir):
+    hid = uuid4().hex[:5]
+    p = Path(tmpdir, hid)
+    p.write_text('\n'.join(['aa,b', 'cc,d']))
+    layout = Layout({'c1': Text(1), 'c2': Text(1)}, no_header=True)
+    errors = CsvFile(layout)._list_errors(p)
+    assert True if len([x for x in errors if type(x) == ex.RowError]) == 2 else False
 
 
 def test_no_header_true_good(tmpdir):


### PR DESCRIPTION
Replacing #72, since that is from a fork and the automated checks aren't executing.