### PR TITLE
Proposed change to behavior interaction between `empty_cols_ok` and 'empty' trailing columns 

### DIFF
--- a/rumydata/__init__.py
+++ b/rumydata/__init__.py
@@ -35,4 +35,4 @@ from rumydata import rules
 from rumydata.menu import menu
 from rumydata.table import *
 
-__version__ = '1.3.0-dev'
+__version__ = '1.4.0'

--- a/rumydata/table.py
+++ b/rumydata/table.py
@@ -286,6 +286,13 @@ class _BaseFile(_BaseSubject):
 
                         bumps = {v: k for k, v in bumps.items()}
                         bumps = [bumps.get(i, f"empty_{uuid4().hex[:5]}") for i in range(len(row))]
+                        # strip out the "trailing" empty columns before updating the field_count for the row length
+                        # rules. These might get picked up when processing excel file layouts based on how the
+                        # worksheet is configured, which would result in a mismatch between the number of columns
+                        # rumydata sees in the row data and the number of columns which get inferred by reading the
+                        # worksheet
+                        while bumps[-1].startswith('empty_'):
+                            bumps.pop()
                         self.layout.layout = {k: self.layout.layout.get(k, field.Empty()) for k in bumps}
 
                         for ix, rule in enumerate(self.layout.rules):  # update row length rules

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -54,6 +54,16 @@ def basic_good_with_empty(tmpdir):
 
 
 @pytest.fixture()
+def basic_good_with_trailing_empty(tmpdir):
+    p = Path(tmpdir, uuid.uuid4().hex)
+    with p.open('w', newline='') as o:
+        writer = csv.writer(o)
+        writer.writerow(['col1', 'col2', 'col3', '', 'col4', '', '', ''])
+        writer.writerow(['A', '1', '2020-01-01', '', 'X'])
+    yield p.as_posix()
+
+
+@pytest.fixture()
 def basic_good_excel(tmpdir):
     p = Path(tmpdir, 'good.xlsx')
     wb = Workbook()
@@ -277,9 +287,10 @@ def test_column_trim():
         field.Text(9, rules=[cr.Unique()], strip=True).check_column(values)
 
 
-def test_empty_column_good(basic, basic_good, basic_good_with_empty):
+def test_empty_column_good(basic, basic_good, basic_good_with_empty, basic_good_with_trailing_empty):
     assert not CsvFile(Layout(basic, empty_cols_ok=True)).check(basic_good_with_empty)
     assert not CsvFile(Layout(basic, empty_cols_ok=True)).check(basic_good)
+    assert not CsvFile(Layout(basic, empty_cols_ok=True)).check(basic_good_with_trailing_empty)
 
 
 def test_empty_column_bad(basic, basic_good_with_empty):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -54,7 +54,7 @@ def basic_good_with_empty(tmpdir):
 
 
 @pytest.fixture()
-def basic_good_with_trailing_empty(tmpdir):
+def basic_good_with_trailing_empty_cols(tmpdir):
     p = Path(tmpdir, uuid.uuid4().hex)
     with p.open('w', newline='') as o:
         writer = csv.writer(o)
@@ -287,10 +287,10 @@ def test_column_trim():
         field.Text(9, rules=[cr.Unique()], strip=True).check_column(values)
 
 
-def test_empty_column_good(basic, basic_good, basic_good_with_empty, basic_good_with_trailing_empty):
+def test_empty_column_good(basic, basic_good, basic_good_with_empty, basic_good_with_trailing_empty_cols):
     assert not CsvFile(Layout(basic, empty_cols_ok=True)).check(basic_good_with_empty)
     assert not CsvFile(Layout(basic, empty_cols_ok=True)).check(basic_good)
-    assert not CsvFile(Layout(basic, empty_cols_ok=True)).check(basic_good_with_trailing_empty)
+    assert not CsvFile(Layout(basic, empty_cols_ok=True)).check(basic_good_with_trailing_empty_cols)
 
 
 def test_empty_column_bad(basic, basic_good_with_empty):


### PR DESCRIPTION
I ran into an issue when trying to validate an Excel file where openpyxl is treating some really far out column to be considered part of the read "data set" (for lack of a better name). In turn, this makes the RowLengthGTE and RowLengthLTE rules to be updated with an extraordinarily large amount for its field_count. The reason for openpyxl reading the excel file in this manner isn't entirely clear to me, but I was able to identify a potential workaround.

After we've determined that the user wants to allow `empty_cols_ok`, there's a step where we try to determine the 'real' number of columns that are empty, and then updating the number of fields each row is expected to have. This update will loop over the updated list of fields (including the "empty" ones), and attempt to remove any of the fields at the end of the sequence of fields that we've added so they won't be used to determine how long the row length should be.