### PR TITLE
Empty cols and rows fix

### DIFF
--- a/rumydata/__init__.py
+++ b/rumydata/__init__.py
@@ -35,4 +35,4 @@ from rumydata import rules
 from rumydata.menu import menu
 from rumydata.table import *
 
-__version__ = '1.4.0-dev'
+__version__ = '1.5.0-dev'

--- a/rumydata/__init__.py
+++ b/rumydata/__init__.py
@@ -35,4 +35,4 @@ from rumydata import rules
 from rumydata.menu import menu
 from rumydata.table import *
 
-__version__ = '1.5.0-dev'
+__version__ = '1.4.1-dev'

--- a/rumydata/table.py
+++ b/rumydata/table.py
@@ -299,6 +299,10 @@ class _BaseFile(_BaseSubject):
                             if isinstance(rule, (rr.RowLengthLTE, rr.RowLengthGTE)):
                                 self.layout.rules[ix].columns_length = self.layout.field_count()
 
+                elif self.layout.empty_cols_ok:
+                    cleaned_col_count = self.layout.field_count()
+                    row = row[:cleaned_col_count]
+                    re = self.layout._check(row, rule_type=rr.Rule, rix=rix)
                 else:
                     re = self.layout._check(row, rule_type=rr.Rule, rix=rix)
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -64,6 +64,16 @@ def basic_good_with_trailing_empty_cols(tmpdir):
 
 
 @pytest.fixture()
+def basic_good_with_trailing_empty_cols_and_rows(tmpdir):
+    p = Path(tmpdir, uuid.uuid4().hex)
+    with p.open('w', newline='') as o:
+        writer = csv.writer(o)
+        writer.writerow(['col1', 'col2', 'col3', '', 'col4', '', '', ''])
+        writer.writerow(['A', '1', '2020-01-01', '', 'X', '', '', ''])
+    yield p.as_posix()
+
+
+@pytest.fixture()
 def basic_good_excel(tmpdir):
     p = Path(tmpdir, 'good.xlsx')
     wb = Workbook()

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -297,10 +297,11 @@ def test_column_trim():
         field.Text(9, rules=[cr.Unique()], strip=True).check_column(values)
 
 
-def test_empty_column_good(basic, basic_good, basic_good_with_empty, basic_good_with_trailing_empty_cols):
+def test_empty_column_good(basic, basic_good, basic_good_with_empty, basic_good_with_trailing_empty_cols, basic_good_with_trailing_empty_cols_and_rows):
     assert not CsvFile(Layout(basic, empty_cols_ok=True)).check(basic_good_with_empty)
     assert not CsvFile(Layout(basic, empty_cols_ok=True)).check(basic_good)
     assert not CsvFile(Layout(basic, empty_cols_ok=True)).check(basic_good_with_trailing_empty_cols)
+    assert not CsvFile(Layout(basic, empty_cols_ok=True)).check(basic_good_with_trailing_empty_cols_and_rows)
 
 
 def test_empty_column_bad(basic, basic_good_with_empty):


### PR DESCRIPTION
Last PR had some handling to fix how the `empty_cols_ok` option was functioning, but I was running into issues when the row also had 'empty' fields within the row. The row data was still reading in more fields in the same way the columns were being read in, but there was no longer to reform the row data when performing it's rule checks.

This change manipulates the row, stripping away all other values after the predetermined "real" column count identified via the `empty_cols_ok` option.