### PR TITLE
Make Excel row_handler not default to empty string value

### DIFF
--- a/rumydata/table.py
+++ b/rumydata/table.py
@@ -432,7 +432,7 @@ class ExcelFile(_BaseFile):
 
     @staticmethod
     def _row_handler(row: list) -> List[str]:
-        return [str(x or '') for x in row]
+        return [str(x) or '' for x in row]
 
 
 class ParquetFile(_BaseFile):


### PR DESCRIPTION
In python, turns out `0 or ''` results in the empty string...

This was causing an issue when an Excel file was reading in a zero (0) integer value, and the row_handler was squashing away the value