### PR TITLE
File write test harness

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -3,6 +3,7 @@ from datetime import datetime as dt
 import pytest
 
 from rumydata import field, rules, exception as ex
+from tests.utils import file_cell_harness
 
 
 def recurse_subclasses(class_to_recurse):
@@ -47,7 +48,9 @@ def test_digest(fo):
     ('', dict(max_length=1, min_length=1, nullable=True))
 ])
 def test_text_good(value, kwargs):
-    assert not field.Text(**kwargs).check_cell(value)
+    fld = field.Text(**kwargs)
+    assert not fld.check_cell(value)
+    assert not file_cell_harness(value, fld)
 
 
 @pytest.mark.parametrize('value,kwargs,rule', [

--- a/tests/test_row.py
+++ b/tests/test_row.py
@@ -2,10 +2,13 @@ import pytest
 
 from rumydata import table, Layout, field
 from rumydata.rules import row as rr, header as hr
+from tests.utils import file_row_harness
 
 
 def test_row_good(basic):
-    assert not table.Layout(basic).check_row(['1', '2', '2020-01-01', 'X'])
+    row = ['1', '2', '2020-01-01', 'X']
+    assert not Layout(basic).check_row(row)
+    assert not file_row_harness(row, basic)
 
 
 def test_row_choice(basic):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,13 @@
+import csv
+import tempfile
+from pathlib import Path
+from typing import List
 from unittest.mock import DEFAULT
+
+import openpyxl
+
+from rumydata import Layout, CsvFile, ExcelFile
+from rumydata.field import Field
 
 
 def mock_no_module(module: str):
@@ -11,3 +20,40 @@ def mock_no_module(module: str):
             return DEFAULT
 
     return func
+
+
+def file_row_harness(row: List[str], layout: dict):
+    """ Write row to file for testing in ingest """
+    lay = Layout(layout, no_header=True)
+
+    with tempfile.TemporaryDirectory() as d:
+        csv_p = Path(d, 'file_test.csv')
+
+        with csv_p.open('w', newline='') as f:
+            writer = csv.writer(f)
+            writer.writerow(row)
+
+        xl_p = Path(d, 'excel_test.xlsx')
+        wb = openpyxl.Workbook()
+        sheet = wb['Sheet']
+        for ix, value in enumerate(row, start=1):
+            sheet.cell(row=1, column=ix).value = value
+        wb.save(filename=xl_p)
+
+        to_check = [
+            ('CsvFile', CsvFile(lay), csv_p),
+            ('ExcelFile', ExcelFile(lay), xl_p)
+        ]
+        aes = []
+        for nm, obj, p in to_check:
+            try:
+                assert not obj.check(p)
+            except AssertionError:
+                aes.append(nm)
+
+        assert not aes, f'Write test failed for {aes}'
+
+
+def file_cell_harness(value: str, field: Field):
+    """ Wrapper to convert cell to row for harness check """
+    file_row_harness(row=[value], layout={'c1': field})


### PR DESCRIPTION
I had an idea for a wrapper that would simplify testing field and row level stuff by writing the values to each file format (CSV, Excel, Parquet (to be implemented)), then doing a generic check on the entire file. We can have this file write harness follow all of the other more specific assertions that we are performing, since we should already know that the lower level functions work as expected. The harness can then do a crude check of whether something weird happens in between the file and the actual test that we're performing.

At this point, the function requires adding a new assertion line to the end of every test that we want to check files. I did two examples, one row, and one field.