### PR TITLE
Release 1.4.2

### DIFF
--- a/rumydata/__init__.py
+++ b/rumydata/__init__.py
@@ -35,4 +35,4 @@ from rumydata import rules
 from rumydata.menu import menu
 from rumydata.table import *
 
-__version__ = '1.4.1'
+__version__ = '1.4.2'

--- a/rumydata/table.py
+++ b/rumydata/table.py
@@ -432,7 +432,7 @@ class ExcelFile(_BaseFile):
 
     @staticmethod
     def _row_handler(row: list) -> List[str]:
-        return [str(x or '') for x in row]
+        return ['' if x is None else str(x) for x in row]
 
 
 class ParquetFile(_BaseFile):

--- a/tests/test_row.py
+++ b/tests/test_row.py
@@ -2,16 +2,22 @@ import pytest
 
 from rumydata import table, Layout, field
 from rumydata.rules import row as rr, header as hr
+from tests.utils import file_row_harness
 
 
 def test_row_good(basic):
-    assert not table.Layout(basic).check_row(['1', '2', '2020-01-01', 'X'])
+    row = ['1', '2', '2020-01-01', 'X']
+    assert not Layout(basic).check_row(row)
+    assert not file_row_harness(row, basic)
 
 
 def test_row_choice(basic):
-    lay = Layout({'c1': field.Choice(['x'], nullable=True)})
+    fields = {'c1': field.Choice(['x'], nullable=True)}
+    lay = Layout(fields)
     assert not lay.check_row(['x'])
     assert not lay.check_row([''])
+    assert not file_row_harness(['x'], fields)
+    assert not file_row_harness([''], fields)
 
 
 @pytest.mark.parametrize('value,err', [
@@ -20,11 +26,12 @@ def test_row_choice(basic):
 ])
 def test_row_bad(basic, value, err):
     assert table.Layout(basic)._has_error(value, err.rule_exception(), rule_type=rr.Rule)
+    with pytest.raises(AssertionError):
+        file_row_harness(value, basic)
 
 
 def test_header_good(basic):
     assert not table.Layout(basic).check_header(['col1', 'col2', 'col3', 'col4'])
-
 
 @pytest.mark.parametrize('value,err', [
     (['col1', 'col2'], hr.NoMissing),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,13 @@
+import csv
+import tempfile
+from pathlib import Path
+from typing import List, Union, Tuple
 from unittest.mock import DEFAULT
+
+import openpyxl
+
+from rumydata import Layout, CsvFile, ExcelFile
+from rumydata.field import Field
 
 
 def mock_no_module(module: str):
@@ -11,3 +20,40 @@ def mock_no_module(module: str):
             return DEFAULT
 
     return func
+
+
+def file_row_harness(row: List[Union[str, int]], layout: dict):
+    """ Write row to file for testing in ingest """
+    lay = Layout(layout, no_header=True)
+
+    with tempfile.TemporaryDirectory() as d:
+        csv_p = Path(d, 'file_test.csv')
+
+        with csv_p.open('w', newline='') as f:
+            writer = csv.writer(f)
+            writer.writerow(row)
+
+        xl_p = Path(d, 'excel_test.xlsx')
+        wb = openpyxl.Workbook()
+        sheet = wb['Sheet']
+        for ix, value in enumerate(row, start=1):
+            sheet.cell(row=1, column=ix).value = value
+        wb.save(filename=xl_p)
+
+        to_check = [
+            ('CsvFile', CsvFile(lay), csv_p),
+            ('ExcelFile', ExcelFile(lay), xl_p)
+        ]
+        aes = {}
+        for nm, obj, p in to_check:
+            try:
+                assert not obj.check(p)
+            except AssertionError as e:
+                aes[nm] = e
+        new_line = '\n'
+        assert not aes, f'Write test failed for:\n {new_line.join([f"{k}:{v}" for k, v in aes.items()])}'
+
+
+def file_cell_harness(value: str, field: Field):
+    """ Wrapper to convert cell to row for harness check """
+    file_row_harness(row=[value], layout={'c1': field})


### PR DESCRIPTION
* Make Excel row_handler not default to empty string value

In python, turns out `0 or ''` results in the empty string...

This was causing an issue when an Excel file was reading in a zero (0) integer value, and the row_handler was squashing away the value

* Add harness to write-test cells and rows

* Add tests for field

* Update rumydata/table.py

Co-authored-by: Christopher Boyd <Mikuana@gmail.com>

* Add various tests using test file 'harness'

* Increment minor version number

* Revert file_cell_harness, use file_row_harness for column compare tests which require a layout that has a column to compare against

* Add file harness testing for empty field

* Move file harness call to its own context manager

Co-authored-by: Jacob Campbell <jacob.campbell@hca.wa.gov>
Co-authored-by: Christopher Boyd <mikuana@gmail.com>