### PR TITLE
Make document generator wait before deleting temp file 

### DIFF
--- a/rumydata/__init__.py
+++ b/rumydata/__init__.py
@@ -35,4 +35,4 @@ from rumydata import rules
 from rumydata.menu import menu
 from rumydata.table import *
 
-__version__ = '1.4.2'
+__version__ = '1.4.3'

--- a/rumydata/menu.py
+++ b/rumydata/menu.py
@@ -124,7 +124,7 @@ def _open_doc(doc: str, ext: str):
         else:
             url = p.as_posix()
         webbrowser.open(url)
-        sleep(0.1)
+        sleep(2)
 
 
 def _select_option(options: dict):


### PR DESCRIPTION
Running this locally would cause my browser to spit out a 'file not found'-style error message. Upping the sleep before killing the temp file, so the browser has the bit of time to read the temp html file.