### PR TITLE
Fix failing 3.11 Windows tests due to temporary files

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,11 @@ from rumydata.field import Text, Integer, Date, Choice
 
 @pytest.fixture()
 def tmpdir():
-    with tempfile.TemporaryDirectory() as d:
-        yield Path(d)
-
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            yield Path(d)
+    except PermissionError:
+        pass
 
 @pytest.fixture()
 def basic() -> dict:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import List, Union, Tuple
 from unittest.mock import DEFAULT
 
+
 import openpyxl
 
 from rumydata import Layout, CsvFile, ExcelFile
@@ -25,32 +26,34 @@ def mock_no_module(module: str):
 def file_row_harness(row: List[Union[str, int]], layout: dict):
     """ Write row to file for testing in ingest """
     lay = Layout(layout, no_header=True)
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            csv_p = Path(d, 'file_test.csv')
 
-    with tempfile.TemporaryDirectory() as d:
-        csv_p = Path(d, 'file_test.csv')
+            with csv_p.open('w', newline='') as f:
+                writer = csv.writer(f)
+                writer.writerow(row)
 
-        with csv_p.open('w', newline='') as f:
-            writer = csv.writer(f)
-            writer.writerow(row)
+            xl_p = Path(d, 'excel_test.xlsx')
+            wb = openpyxl.Workbook()
+            sheet = wb['Sheet']
+            for ix, value in enumerate(row, start=1):
+                sheet.cell(row=1, column=ix).value = value
+            wb.save(filename=xl_p)
 
-        xl_p = Path(d, 'excel_test.xlsx')
-        wb = openpyxl.Workbook()
-        sheet = wb['Sheet']
-        for ix, value in enumerate(row, start=1):
-            sheet.cell(row=1, column=ix).value = value
-        wb.save(filename=xl_p)
-
-        to_check = [
-            ('CsvFile', CsvFile(lay), csv_p),
-            ('ExcelFile', ExcelFile(lay), xl_p)
-        ]
-        aes = {}
-        for nm, obj, p in to_check:
-            try:
-                assert not obj.check(p)
-            except AssertionError as e:
-                aes[nm] = e
-        new_line = '\n'
+            to_check = [
+                ('CsvFile', CsvFile(lay), csv_p),
+                ('ExcelFile', ExcelFile(lay), xl_p)
+            ]
+            aes = {}
+            for nm, obj, p in to_check:
+                try:
+                    assert not obj.check(p)
+                except AssertionError as e:
+                    aes[nm] = e
+            new_line = '\n'
+        assert not aes, f'Write test failed for:\n {new_line.join([f"{k}:{v}" for k, v in aes.items()])}'
+    except PermissionError:
         assert not aes, f'Write test failed for:\n {new_line.join([f"{k}:{v}" for k, v in aes.items()])}'
 
 


### PR DESCRIPTION
I couldn't replicate these tests failing locally at all (something specific to the runner?).

I eventually found this [pytest issue](https://github.com/pytest-dev/pytest/issues/7491) that discusses
similar(ish) behaviors. This lead me to attempt to catch the PermissionError exceptions and essentially ignore them.

I'm not sure if this is a good approach, but it appears to resolve the issue.